### PR TITLE
Adapt butterfly board implementation to changes in MPU9250 library

### DIFF
--- a/src/boards/butterfly.hpp
+++ b/src/boards/butterfly.hpp
@@ -152,11 +152,6 @@ namespace hf {
                     float ax = imuData[0]*aRes - accelBias[0];  // get actual g value, this depends on scale being set
                     float ay = imuData[1]*aRes - accelBias[1];
                     float az = imuData[2]*aRes - accelBias[2];
-                    Serial.print(ax);
-                    Serial.print(",");
-                    Serial.print(ay);
-                    Serial.print(",");
-                    Serial.println(az);
 
                     // Convert the gyro value into degrees per second
                     float gx = adc2rad(imuData[4]);


### PR DESCRIPTION
**Note**: The important changes are from line 41 to 45. The rest is just removing whitespace.

## Issue this PR addresses 

Due to changes in the MPU9250 drivers the sample code `ButterflySBUS.ino` started giving an error when compiling. 

My guess is that the error is due to the changes in the constructor of the class `MPU9250Passthru`. See: https://github.com/simondlevy/MPU9250/blob/a810de293412707727941942e3e418cb1c03b8e4/src/MPU9250.h#L250 

## Current behavior before PR

When trying to compile `ButterflySBUS.ino` the following error is raised (for brevity, only the first lines are shown):
```
In file included from /home/juan/Arduino/libraries/Hackflight/examples/ButterflySBUS/ButterflySBUS.ino:22:0:
/home/juan/Arduino/libraries/Hackflight/src/boards/butterfly.hpp:44:54: error:
 no matching function for call to 'MPU9250Passthru::MPU9250Passthru(ArduinoI2C*)'
             MPU9250Passthru imu = MPU9250Passthru(&bt);;
```

## Expected behavior after PR is merged

The code compiles and works without errors. The solution has been to create the two required byte-transfer objects for Arduino I^2C and pass them by reference to the constructor of `MPU9250Passthru`