### PR TITLE
Use MPU9250 pass-through mode for Butterfly board

### DIFF
--- a/src/boards/butterfly.hpp
+++ b/src/boards/butterfly.hpp
@@ -27,7 +27,7 @@
 #include <Wire.h>
 #include <Servo.h>
 
-#include <MPU9250.h> 
+#include <MPU9250_Passthru.h>
 
 #include "filters.hpp"
 #include "hackflight.hpp"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When trying to compile Hackflight for the Butterfly board an exception is raised and the code doesn't compile.

## Current behavior before PR

Trying to compile any of Hackflight examples' for the Butterfly board raises the error:

```
/home/juan/Arduino/libraries/Hackflight/src/boards/butterfly.hpp:77:13: error: 'MPU9250_Passthru' does not name a type
```

I guess this is due to the restructure of  the [MPU library](https://github.com/simondlevy/MPU), which made the following include obsolete.
https://github.com/simondlevy/Hackflight/blob/16a87f5f6118d7dce8f5e4266d2ba3aca8487d47/src/boards/butterfly.hpp#L30

## Desired behavior after PR is merged

Hackflight compiles for the Butterfly board without errors.
