### PR TITLE
Butterfly board and BonaDrone's FC brushless motor support  

### DIFF
--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -47,6 +47,12 @@ namespace hf {
             // LSM6DSM data-ready interrupt pin
             const uint8_t LSM6DSM_INTERRUPT_PIN = 2;
 
+            const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
+            
+            // Min, max PWM values
+            const uint16_t PWM_MIN = 1000;
+            const uint16_t PWM_MAX = 2000;
+            
             // Paramters to experiment with ------------------------------------------------------------------------
 
             // LSM6DSM full-scale settings
@@ -103,9 +109,7 @@ namespace hf {
 
             void writeMotor(uint8_t index, float value)
             {
-                // XXX
-                (void)index;
-                (void)value;
+                analogWrite(MOTOR_PINS[index], (uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)) >> 3);
             }
 
             virtual uint32_t getMicroseconds(void) override
@@ -153,7 +157,10 @@ namespace hf {
                 pinMode(LSM6DSM_INTERRUPT_PIN, INPUT);
 
                 // Connect to the ESCs and send them the baseline values
-                // XXX
+                for (uint8_t k=0; k<4; ++k) {
+                  pinMode(MOTOR_PINS[k], OUTPUT);
+                  analogWrite(MOTOR_PINS[k], PWM_MIN>>3);
+                }
 
                 // Start I^2C
                 Wire.begin(TWI_PINS_20_21);

--- a/src/boards/butterfly.hpp
+++ b/src/boards/butterfly.hpp
@@ -2,6 +2,9 @@
    butterfly.hpp : Implementation of Hackflight Board routines for Butterfly
                    dev board + MPU9250 IMU + MS5637 barometer + brushless motors
 
+   Additional libraries required: https://github.com/simondlevy/MPU9250
+                                  https://github.com/simondlevy/MS5637
+
    Copyright (c) 2018 Simon D. Levy
 
    This file is part of Hackflight.

--- a/src/boards/butterfly.hpp
+++ b/src/boards/butterfly.hpp
@@ -47,7 +47,7 @@ namespace hf {
             const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
 
             // Min, max PWM values
-            const uint16_t PWM_MIN = 990;
+            const uint16_t PWM_MIN = 1000;
             const uint16_t PWM_MAX = 2000;
 
             // Butterfly board follows Arduino standard for LED pin
@@ -72,9 +72,6 @@ namespace hf {
 
             // Use the MPU9250 in pass-through mode
             MPU9250_Passthru _imu = MPU9250_Passthru(ASCALE, GSCALE, MSCALE, MMODE, SAMPLE_RATE_DIVISOR);
-
-            // Run motor ESCs using standard Servo library
-            Servo _escs[4];
 
        protected:
 
@@ -105,7 +102,7 @@ namespace hf {
 
             void writeMotor(uint8_t index, float value)
             {
-                _escs[index].writeMicroseconds((uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)));
+                analogWrite(MOTOR_PINS[index], (uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)) >> 3);
             }
 
             virtual uint32_t getMicroseconds(void) override
@@ -160,8 +157,8 @@ namespace hf {
 
                 // Connect to the ESCs and send them the baseline values
                 for (uint8_t k=0; k<4; ++k) {
-                    _escs[k].attach(MOTOR_PINS[k]);
-                    _escs[k].writeMicroseconds(PWM_MIN);
+                  pinMode(MOTOR_PINS[k], OUTPUT);
+                  analogWrite(MOTOR_PINS[k], PWM_MIN>>3);
                 }
 
                 // Start I^2C

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -89,12 +89,12 @@ namespace hf {
 
         // channel indices
         enum {
-            CHANNEL_THROTTLE, 
             CHANNEL_ROLL,    
             CHANNEL_PITCH,  
+            CHANNEL_THROTTLE, 
             CHANNEL_YAW,   
-            CHANNEL_AUX1,
-            CHANNEL_AUX2
+            CHANNEL_AUX2,
+            CHANNEL_AUX1
         };
 
         uint8_t _channelMap[6];


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Implement, both for the butterfly board and BonaDrone's FC:
1. The initialization of the ESCs that supports brush-less motors
2. Method to write values to the motors that supports brush-less motors. 

## Current behavior before PR

There is no brush-less motors support for the butterfly board or BonaDrone's FC

## Desired behavior after PR is merged

PWM values are written to the motors at the desired frequency and the ESCs are properly initialized.
