### PR TITLE
Fix transmitter demands incoherences

### DIFF
--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -47,7 +47,7 @@ namespace hf {
         {
             command /= 2;
 
-            if (rawvals[channel] < 0) {
+            if (rawvals[_channelMap[channel]] < 0) {
                 command = -command;
             }
 
@@ -61,7 +61,7 @@ namespace hf {
 
         float makePositiveCommand(uint8_t channel)
         {
-            return fabs(rawvals[channel]);
+            return fabs(rawvals[_channelMap[channel]]);
         }
 
         static float rcFun(float x, float e, float r)
@@ -143,18 +143,18 @@ namespace hf {
             readRawvals();
 
             // Convert raw [-1,+1] to absolute value
-            demands.roll  = makePositiveCommand(_channelMap[CHANNEL_ROLL]);
-            demands.pitch = makePositiveCommand(_channelMap[CHANNEL_PITCH]);
-            demands.yaw   = makePositiveCommand(_channelMap[CHANNEL_YAW]);
+            demands.roll  = makePositiveCommand(CHANNEL_ROLL);
+            demands.pitch = makePositiveCommand(CHANNEL_PITCH);
+            demands.yaw   = makePositiveCommand(CHANNEL_YAW);
 
             // Apply expo nonlinearity to roll, pitch
             demands.roll  = applyCyclicFunction(demands.roll);
             demands.pitch = applyCyclicFunction(demands.pitch);
 
             // Put sign back on command, yielding [-0.5,+0.5]
-            demands.roll  = adjustCommand(demands.roll, _channelMap[CHANNEL_ROLL]);
-            demands.pitch = adjustCommand(demands.pitch, _channelMap[CHANNEL_PITCH]);
-            demands.yaw   = adjustCommand(demands.yaw, _channelMap[CHANNEL_YAW]);
+            demands.roll  = adjustCommand(demands.roll, CHANNEL_ROLL);
+            demands.pitch = adjustCommand(demands.pitch,CHANNEL_PITCH);
+            demands.yaw   = adjustCommand(demands.yaw, CHANNEL_YAW);
 
             // Add in software trim
             demands.roll  += _trimRoll;

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -175,7 +175,7 @@ namespace hf {
             demands.yaw = -demands.yaw;
 
             // Pass throttle demand through exponential function
-            demands.throttle = throttleFun(rawvals[CHANNEL_THROTTLE]);
+            demands.throttle = throttleFun(rawvals[_channelMap[CHANNEL_THROTTLE]]);
             
             // Store auxiliary switch state
             _aux1State = getRawval(CHANNEL_AUX1) >= 0.0 ? (getRawval(CHANNEL_AUX1) > .4 ? 2 : 1) : 0;

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -143,18 +143,18 @@ namespace hf {
             readRawvals();
 
             // Convert raw [-1,+1] to absolute value
-            demands.roll  = makePositiveCommand(CHANNEL_ROLL);
-            demands.pitch = makePositiveCommand(CHANNEL_PITCH);
-            demands.yaw   = makePositiveCommand(CHANNEL_YAW);
+            demands.roll  = makePositiveCommand(_channelMap[CHANNEL_ROLL]);
+            demands.pitch = makePositiveCommand(_channelMap[CHANNEL_PITCH]);
+            demands.yaw   = makePositiveCommand(_channelMap[CHANNEL_YAW]);
 
             // Apply expo nonlinearity to roll, pitch
             demands.roll  = applyCyclicFunction(demands.roll);
             demands.pitch = applyCyclicFunction(demands.pitch);
 
             // Put sign back on command, yielding [-0.5,+0.5]
-            demands.roll  = adjustCommand(demands.roll, CHANNEL_ROLL);
-            demands.pitch = adjustCommand(demands.pitch, CHANNEL_PITCH);
-            demands.yaw   = adjustCommand(demands.yaw, CHANNEL_YAW);
+            demands.roll  = adjustCommand(demands.roll, _channelMap[CHANNEL_ROLL]);
+            demands.pitch = adjustCommand(demands.pitch, _channelMap[CHANNEL_PITCH]);
+            demands.yaw   = adjustCommand(demands.yaw, _channelMap[CHANNEL_YAW]);
 
             // Add in software trim
             demands.roll  += _trimRoll;


### PR DESCRIPTION
## Description of the issue this PR addresses

When initializing the receiver class one is allowed to define a particular channel map so that it matches with his setup:

https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/examples/Bonadrone/SBUS/SBUS.ino#L41

where the meaning of each position is:
* Position 0: throttle channel
* Position 1: roll channel
* Position 2: pitch channel
* Position 3: yaw channel
* Position 4: aux channel
* Position 5: arm channel

as stated in:
https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/src/receiver.hpp#L88-L96

The receiver then gets this map and stores it:

https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/src/receiver.hpp#L129

Once a new set of demands is received, this user-defined mapping should be taken into account everywhere to match each demand with its meaning. As an example, to get the throttle one should call:

```
rawvals[_channelMap[CHANNEL_THROTTLE]]
```
and not
```
rawvals[CHANNEL_THROTTLE]
```
since the actual throttle channel is not `0` but `_channelMap[0]`.

There are some places were this is indeed taken into account:

https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/src/receiver.hpp#L119-L122

But many others were it isn't:

https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/src/receiver.hpp#L146-L148

https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/src/receiver.hpp#L62-L65

https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/src/receiver.hpp#L155-L157

https://github.com/simondlevy/Hackflight/blob/e656675150b99c57e0cf45cf3c5c848dc16ce955/src/receiver.hpp#L46-L55

This will result in a wrong interpretation of the demand.

If the channel map casually matches the order defined in the `enum` of channels there are no problems because mappings are coherent but otherwise the received demands are not properly matched to its meaning. This results in the controller misinterpreting the demands.
