### PR TITLE
Use error derivative as the input for the stabilizer's derivative part

### DIFF
--- a/src/pidcontrollers/stabilizer.hpp
+++ b/src/pidcontrollers/stabilizer.hpp
@@ -97,7 +97,7 @@ namespace hf {
             {
                 PTerm -= gyro[axis] * rateP; 
 
-                return PTerm + ITerm - DTerm;
+                return PTerm + ITerm + DTerm;
             }
 
             // Computes leveling PID for pitch or roll

--- a/src/pidcontrollers/stabilizer.hpp
+++ b/src/pidcontrollers/stabilizer.hpp
@@ -61,9 +61,9 @@ namespace hf {
             float _gyroYawP; 
             float _gyroYawI;
 
-            float _lastGyro[2];
-            float _gyroDelta1[2]; 
-            float _gyroDelta2[2];
+            float _lastError[2];
+            float _gyroDeltaError1[2]; 
+            float _gyroDeltaError2[2];
             float _errorGyroI[3];
 
             // For PTerm computation
@@ -81,10 +81,8 @@ namespace hf {
                 return M_PI * deg / 180.;
             }
 
-            float computeITermGyro(float rateP, float rateI, float rcCommand, float gyro[3], uint8_t axis)
+            float computeITermGyro(float error, float rateI, float rcCommand, float gyro[3], uint8_t axis)
             {
-                float error = rcCommand*rateP - gyro[axis];
-
                 // Avoid integral windup
                 _errorGyroI[axis] = Filter::constrainAbs(_errorGyroI[axis] + error, GYRO_WINDUP_MAX);
 
@@ -119,17 +117,18 @@ namespace hf {
             // Computes leveling PID for pitch or roll
             float computeCyclicPid(float rcCommand, float gyro[3], uint8_t imuAxis)
             {
+                float error = rcCommand * _gyroCyclicP - gyro[imuAxis];
                 // I
-                float ITerm = computeITermGyro(_gyroCyclicP, _gyroCyclicI, rcCommand, gyro, imuAxis);
+                float ITerm = computeITermGyro(error, _gyroCyclicI, rcCommand, gyro, imuAxis);
                 ITerm *= _proportionalCyclicDemand;
 
                 // D
-                float _gyroDelta = gyro[imuAxis] - _lastGyro[imuAxis];
-                _lastGyro[imuAxis] = gyro[imuAxis];
-                float _gyroDeltaSum = _gyroDelta1[imuAxis] + _gyroDelta2[imuAxis] + _gyroDelta;
-                _gyroDelta2[imuAxis] = _gyroDelta1[imuAxis];
-                _gyroDelta1[imuAxis] = _gyroDelta;
-                float DTerm = _gyroDeltaSum * _gyroCyclicD; 
+                float _gyroDeltaError = error - _lastError[imuAxis];
+                _lastError[imuAxis] = error;
+                float _gyroDeltaErrorSum = _gyroDeltaError1[imuAxis] + _gyroDeltaError2[imuAxis] + _gyroDeltaError;
+                _gyroDeltaError2[imuAxis] = _gyroDeltaError1[imuAxis];
+                _gyroDeltaError1[imuAxis] = _gyroDeltaError;
+                float DTerm = _gyroDeltaErrorSum * _gyroCyclicD; 
 
                 return computePid(_gyroCyclicP, _PTerm[imuAxis], ITerm, DTerm, gyro, imuAxis);
             }
@@ -161,9 +160,9 @@ namespace hf {
                 _gyroYawI(gyroYawI) 
             {                // Zero-out previous values for D term
                 for (uint8_t axis=0; axis<2; ++axis) {
-                    _lastGyro[axis] = 0;
-                    _gyroDelta1[axis] = 0;
-                    _gyroDelta2[axis] = 0;
+                    _lastError[axis] = 0;
+                    _gyroDeltaError1[axis] = 0;
+                    _gyroDeltaError2[axis] = 0;
                 }
 
                 // Convert degree parameters to radians for use later
@@ -201,7 +200,8 @@ namespace hf {
                 demands.pitch = computeCyclicPid(demands.pitch, state.angularVelocities, AXIS_PITCH);
 
                 // For gyroYaw, P term comes directly from RC command, and D term is zero
-                float ITermGyroYaw = computeITermGyro(_gyroYawP, _gyroYawI, demands.yaw, state.angularVelocities, AXIS_YAW);
+                float yawError = demands.yaw * _gyroYawP - state.angularVelocities[AXIS_YAW];
+                float ITermGyroYaw = computeITermGyro(yawError, _gyroYawI, demands.yaw, state.angularVelocities, AXIS_YAW);
                 demands.yaw = computePid(_gyroYawP, demands.yaw, ITermGyroYaw, 0, state.angularVelocities, AXIS_YAW);
 
                 // Prevent "gyroYaw jump" during gyroYaw correction


### PR DESCRIPTION
For a bit of context, the issue explained below arose when trying to tune the PID parameters. Giving the parameter `_gyroCyclicD` a value different than 0 made the quadcopter hard to fly. I _think_ the following might be a correct diagnosis of what is going on.

When computing the roll, pitch and yaw control actions the current input of the PID controller derivative part is the gyroscope's rate of change in the respective axis.

https://github.com/simondlevy/Hackflight/blob/d4eac338c6c12f8d2563830a99957ff3ec542ca2/src/pidcontrollers/stabilizer.hpp#L127-L132

The value obtained from the previous snippet is then subtracted when computing the control action: 

https://github.com/simondlevy/Hackflight/blob/d4eac338c6c12f8d2563830a99957ff3ec542ca2/src/pidcontrollers/stabilizer.hpp#L102

If I'm not mistaken, this approach results in the D term acting as a damping source where the damping action is proportional to the gyro-rate derivative, pretty much the way this same term would behave if the error derivative is used as input. Furthermore, it tries to bring the gyro-rate derivative to 0 and delegates reaching the reference signal to the P and I parts.

While I agree that with proper parameter tunning this implementation will work in the majority of cases, I think that we are missing out the full potential of the D term (and the cost of implementing it properly is really small) when trying to bring the error between reference signal and system state to 0. Moreover, there are a set of cases in which I think this approach will backfire and fail to produce the desired control action. Tracking a ramp input (although I agree it might not be usual in the current context) is an example that comes to my mind right now. 

I'm open for discussion but I believe that, a part from standardizing the PID control loop, the control will improve if we use the error derivative as the input of the D term.

## Current control loop:
![pid-loop-original](https://user-images.githubusercontent.com/9968427/46654299-cd0e2280-cba8-11e8-9df2-af9a199a4535.png)

## Proposed control loop:
![pid-derivative-mod](https://user-images.githubusercontent.com/9968427/46654303-d0091300-cba8-11e8-8a1c-67268282395a.png)
