### PR TITLE
Control Loop modifications

### DIFF
--- a/src/pidcontrollers/stabilizer.hpp
+++ b/src/pidcontrollers/stabilizer.hpp
@@ -97,7 +97,7 @@ namespace hf {
             {
                 PTerm = PTerm * rateP -gyro[axis];
 
-                return PTerm + ITerm - DTerm;
+                return PTerm + ITerm + DTerm;
             }
 
             // Computes leveling PID for pitch or roll

--- a/src/pidcontrollers/stabilizer.hpp
+++ b/src/pidcontrollers/stabilizer.hpp
@@ -97,7 +97,7 @@ namespace hf {
 
             float computePid(float rateP, float PTerm, float ITerm, float DTerm, float gyro[3], uint8_t axis)
             {
-                PTerm -= gyro[axis] * rateP; 
+                PTerm = PTerm * rateP -gyro[axis];
 
                 return PTerm + ITerm - DTerm;
             }

--- a/src/pidcontrollers/stabilizer.hpp
+++ b/src/pidcontrollers/stabilizer.hpp
@@ -61,9 +61,9 @@ namespace hf {
             float _gyroYawP; 
             float _gyroYawI;
 
-            float _lastGyro[2];
-            float _gyroDelta1[2]; 
-            float _gyroDelta2[2];
+            float _lastError[2];
+            float _gyroDeltaError1[2]; 
+            float _gyroDeltaError2[2];
             float _errorGyroI[3];
 
             // For PTerm computation
@@ -81,10 +81,8 @@ namespace hf {
                 return M_PI * deg / 180.;
             }
 
-            float computeITermGyro(float rateP, float rateI, float rcCommand, float gyro[3], uint8_t axis)
+            float computeITermGyro(float error, float rateI, float rcCommand, float gyro[3], uint8_t axis)
             {
-                float error = rcCommand*rateP - gyro[axis];
-
                 // Avoid integral windup
                 _errorGyroI[axis] = Filter::constrainAbs(_errorGyroI[axis] + error, GYRO_WINDUP_MAX);
 
@@ -119,17 +117,18 @@ namespace hf {
             // Computes leveling PID for pitch or roll
             float computeCyclicPid(float rcCommand, float gyro[3], uint8_t imuAxis)
             {
+                float error = rcCommand * _gyroCyclicP - gyro[imuAxis];
                 // I
-                float ITerm = computeITermGyro(_gyroCyclicP, _gyroCyclicI, rcCommand, gyro, imuAxis);
+                float ITerm = computeITermGyro(error, _gyroCyclicI, rcCommand, gyro, imuAxis);
                 ITerm *= _proportionalCyclicDemand;
 
                 // D
-                float _gyroDelta = gyro[imuAxis] - _lastGyro[imuAxis];
-                _lastGyro[imuAxis] = gyro[imuAxis];
-                float _gyroDeltaSum = _gyroDelta1[imuAxis] + _gyroDelta2[imuAxis] + _gyroDelta;
-                _gyroDelta2[imuAxis] = _gyroDelta1[imuAxis];
-                _gyroDelta1[imuAxis] = _gyroDelta;
-                float DTerm = _gyroDeltaSum * _gyroCyclicD; 
+                float _gyroDeltaError = error - _lastError[imuAxis];
+                _lastError[imuAxis] = error;
+                float _gyroDeltaErrorSum = _gyroDeltaError1[imuAxis] + _gyroDeltaError2[imuAxis] + _gyroDeltaError;
+                _gyroDeltaError2[imuAxis] = _gyroDeltaError1[imuAxis];
+                _gyroDeltaError1[imuAxis] = _gyroDeltaError;
+                float DTerm = _gyroDeltaErrorSum * _gyroCyclicD; 
 
                 return computePid(_gyroCyclicP, _PTerm[imuAxis], ITerm, DTerm, gyro, imuAxis);
             }
@@ -161,9 +160,9 @@ namespace hf {
                 _gyroYawI(gyroYawI) 
             {                // Zero-out previous values for D term
                 for (uint8_t axis=0; axis<2; ++axis) {
-                    _lastGyro[axis] = 0;
-                    _gyroDelta1[axis] = 0;
-                    _gyroDelta2[axis] = 0;
+                    _lastError[axis] = 0;
+                    _gyroDeltaError1[axis] = 0;
+                    _gyroDeltaError2[axis] = 0;
                 }
 
                 // Convert degree parameters to radians for use later
@@ -201,7 +200,8 @@ namespace hf {
                 demands.pitch = computeCyclicPid(demands.pitch, state.angularVelocities, AXIS_PITCH);
 
                 // For gyroYaw, P term comes directly from RC command, and D term is zero
-                float ITermGyroYaw = computeITermGyro(_gyroYawP, _gyroYawI, demands.yaw, state.angularVelocities, AXIS_YAW);
+                float yawError = demands.yaw * _gyroYawP - state.angularVelocities[AXIS_YAW];
+                float ITermGyroYaw = computeITermGyro(yawError, _gyroYawI, demands.yaw, state.angularVelocities, AXIS_YAW);
                 demands.yaw = computePid(_gyroYawP, demands.yaw, ITermGyroYaw, 0, state.angularVelocities, AXIS_YAW);
 
                 // Prevent "gyroYaw jump" during gyroYaw correction


### PR DESCRIPTION
This [video](https://www.youtube.com/watch?v=qT_n1F6LhgE) shows the results obtained with the proposed changes.


**Important Notes**:
1. This PR supersedes #28 (will keep it open because #28 can be merged independently and has a smaller impact on the code).

2. If this PR is merged any aircraft flying with Hackflight will have to be re-tuned.

3. Everything explained below is done under the assumption that stick inputs correspond to desired rates and that the desired multicopter behavior is the _Ideal ACRO mode_:
    > The ideal ACRO mode is "Fly by wire". By that I mean that the airframe is stabilized as it is in STABILIZE mode but controlled by rate inputs like it is and ACRO mode.

    See: https://diydrones.com/profiles/blogs/acro-mode-pid-options-and-fly-by-wire

## Integral part
When computing the error we are using the formula:
https://github.com/simondlevy/Hackflight/blob/d4eac338c6c12f8d2563830a99957ff3ec542ca2/src/pidcontrollers/stabilizer.hpp#L86
where `rateP` is `_gyroCyclicP`. I think that what should be done here is map the `rcCommand` to a rate via `_demandsToRate` instead of via `_gyroCiclycP` before calculating the error. As I see it, `_gyroCiclycP` should be used as the gain of the proportional part of the controller (see diagrams below).

## Derivative part
When computing the roll, pitch and yaw control actions the current input of the PID controller derivative part is the gyroscope's rate of change in the respective axis.

https://github.com/simondlevy/Hackflight/blob/d4eac338c6c12f8d2563830a99957ff3ec542ca2/src/pidcontrollers/stabilizer.hpp#L127-L132

The value obtained from the previous snippet is then subtracted when computing the control action: 

https://github.com/simondlevy/Hackflight/blob/d4eac338c6c12f8d2563830a99957ff3ec542ca2/src/pidcontrollers/stabilizer.hpp#L102

If I'm not mistaken, this approach results in the D term acting as a damping source where the damping action is proportional to the gyro-rate derivative, pretty much the way this same term would behave if the error derivative is used as input. Furthermore, it tries to bring the gyro-rate derivative to 0 and delegates reaching the reference signal to the P and I parts.

While I agree that with proper parameter tunning this implementation will work in the majority of cases, I think that we are missing out the full potential of the D term (and the cost of implementing it properly is really small) when trying to bring the error between reference signal and system state to 0. Moreover, there are a set of cases in which I think this approach will backfire and fail to produce the desired control action. Tracking a ramp input (although I agree it might not be usual in the current context) is an example that comes to my mind right now. 

I'm open for discussion but I believe that, a part from standardizing the PID control loop, the control will improve if we use the error derivative as the input of the D term.

## Proportional part
I have no idea of why the measured rate is being multiplied by the constant `rateP` (which in the end is `_gyroCyclicP`) before being subtracted from the reference signal.
https://github.com/simondlevy/Hackflight/blob/d4eac338c6c12f8d2563830a99957ff3ec542ca2/src/pidcontrollers/stabilizer.hpp#L100
I think the logical operation is:
```
(reference - measure) * P
```
where `reference` should have the same units as `measure`. This is why it is suggested to multiply `PTerm` by `_demandsToRate` before comparing them.   

## Pending

1. Assuming that the input of the proportional part (`PTerm`) should be mapped from input to rate via `_demandsToRate` might be too much. If the `aux` is set the multicopter should level itself when no inputs are detected. We should put some work into the computation of the `PTerm` and see if any modifications should be done.
2. I have no idea of why the integral part is multiplied by `proportionalCyclicDemands`. It should be reviewed more in detail to understand what's going on.

## Diagrams
### Original Control Loop
![pid-loop-original](https://user-images.githubusercontent.com/9968427/46658365-db613c00-cbb2-11e8-8fc1-f0b6dca5f20f.png)

### Modifications
![pid-mod](https://user-images.githubusercontent.com/9968427/46658370-def4c300-cbb2-11e8-824c-f2fe2f67a7a8.png)

### Proposed Control Loop
![pid-modified](https://user-images.githubusercontent.com/9968427/46658384-e4520d80-cbb2-11e8-9b27-f6613dc8e8ae.png)
