### PR TITLE
Add Level PID controller

### DIFF
--- a/examples/Bonadrone/SBUSLevel/SBUSLevel.ino
+++ b/examples/Bonadrone/SBUSLevel/SBUSLevel.ino
@@ -73,6 +73,8 @@ void setup(void)
     rc.setTrimPitch(-0.0058769f);
     rc.setTrimYaw(-0.0192190f);
 
+    // 0 means the controller will always be active, but by changing
+    // that number it can be linked to a different aux state
     h.addPidController(&level, 0);
 
     h.init(new hf::Bonadrone(), &rc, &mixer, &stabilizer);

--- a/examples/Bonadrone/SBUSLevel/SBUSLevel.ino
+++ b/examples/Bonadrone/SBUSLevel/SBUSLevel.ino
@@ -1,0 +1,84 @@
+/*
+   SBUS.ino : Hackflight sketch for Bonadrone flight controller with SBUS receiver
+
+   Additional libraries needed:
+
+       https://github.com/simondlevy/LSM6DSM
+       https://github.com/simondlevy/CrossPlatformDataBus
+       https://github.com/simondlevy/SBUSRX
+
+   Hardware support for Bonadrone flight controller:
+
+       https://github.com/simondlevy/grumpyoldpizza
+
+   Copyright (c) 2018 Simon D. Levy
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Arduino.h>
+
+#include "hackflight.hpp"
+#include "boards/bonadrone.hpp"
+#include "receivers/sbus.hpp"
+#include "mixers/quadx.hpp"
+
+#include "pidcontrollers/level.hpp"
+
+// Change this as needed
+#define SBUS_SERIAL Serial1
+
+static constexpr uint8_t CHANNEL_MAP[6] = {2,0,1,3,5,4};
+
+hf::Hackflight h;
+
+hf::SBUS_Receiver rc = hf::SBUS_Receiver(CHANNEL_MAP, SERIAL_SBUS, &SBUS_SERIAL);
+
+hf::MixerQuadX mixer;
+
+hf::Stabilizer stabilizer = hf::Stabilizer(
+                0.10f,   // Gyro Roll P
+                0.01f,   // Gyro Roll I
+                0.05f,   // Gyro Roll D
+                0.20f,   // Gyro Pitch P
+                0.01f,   // Gyro Pitch I
+                0.05f,   // Gyro Pitch D
+                0.10f,   // Gyro yaw P
+                0.01f,   // Gyro yaw I
+                8.58f); // Demands to rate
+
+hf::Level level = hf::Level(
+                0.25f,   // Roll Level P
+                0.25f);  // Pitch Level P
+
+void setup(void)
+{
+    // begin the serial port for the ESP32
+    Serial4.begin(115200);
+
+    // Trim receiver via software
+    rc.setTrimRoll(-0.0012494f);
+    rc.setTrimPitch(-0.0058769f);
+    rc.setTrimYaw(-0.0192190f);
+
+    h.addPidController(&level, 0);
+
+    h.init(new hf::Bonadrone(), &rc, &mixer, &stabilizer);
+}
+
+void loop(void)
+{
+    h.update();
+}

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -108,9 +108,6 @@ namespace hf {
                     // For PID control, start with demands from receiver
                     memcpy(&_demands, &_receiver->demands, sizeof(demands_t));
 
-                    // Update stabilizer with new Euler angles
-                    //_stabilizer->updateEulerAngles(_demands, _state.eulerAngles, _receiver->getAux1State());
-
                     // Synch PID controllers to gyro update
                     runPidControllers();
 
@@ -301,7 +298,6 @@ namespace hf {
 
                 // Support adding new sensors and PID controllers
                 _sensor_count = 0;
-                //_pid_controller_count = 0;
 
                 // Last PID controller is always stabilizer (rate), aux state = 0
                 addPidController(stabilizer, 0);

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -50,7 +50,7 @@ namespace hf {
 
             // PID controllers
             PID_Controller * _pid_controllers[256];
-            uint8_t _pid_controller_count;
+            uint8_t _pid_controller_count = 0;
 
             // Mandatory sensors on the board
             Gyrometer _gyrometer;
@@ -89,9 +89,6 @@ namespace hf {
                     // Update state with new quaternion to yield Euler angles
                     _quaternion.modifyState(_state, time);
 
-                    // Update stabilizer with new Euler angles
-                    _stabilizer->updateEulerAngles(_state.eulerAngles, _receiver->getAux1State());
-
                     // Synch serial comms to quaternion check
                     doSerialComms();
                 }
@@ -110,6 +107,9 @@ namespace hf {
 
                     // For PID control, start with demands from receiver
                     memcpy(&_demands, &_receiver->demands, sizeof(demands_t));
+
+                    // Update stabilizer with new Euler angles
+                    //_stabilizer->updateEulerAngles(_demands, _state.eulerAngles, _receiver->getAux1State());
 
                     // Synch PID controllers to gyro update
                     runPidControllers();
@@ -301,9 +301,9 @@ namespace hf {
 
                 // Support adding new sensors and PID controllers
                 _sensor_count = 0;
-                _pid_controller_count = 0;
+                //_pid_controller_count = 0;
 
-                // First PID controller is always stabilizer, aux state = 0
+                // Last PID controller is always stabilizer (rate), aux state = 0
                 addPidController(stabilizer, 0);
 
                 // Initialize state

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -1,0 +1,77 @@
+/*
+   stabilizer.hpp : PID-based stabilization 
+
+   Copyright (c) 2018 Simon D. Levy
+   Author: Juan Gallostra
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <limits>
+#include <cmath>
+
+#include "receiver.hpp"
+#include "filters.hpp"
+#include "debug.hpp"
+#include "datatypes.hpp"
+#include "pidcontroller.hpp"
+
+namespace hf {
+
+    class Level : public PID_Controller {
+
+        friend class Hackflight;
+
+        private:
+          
+            const float FF = 0.5;
+            
+            float PTerms[2];
+            
+            float _demandsToAngle;
+
+        public:
+
+            Level(float rollLevelP, float pitchLevelP, float maxAngle = 10)
+            {
+                PTerms[0] = rollLevelP;
+                PTerms[1] = pitchLevelP;
+                _demandsToAngle = maxAngle * 2 * M_PI / 180.0f;
+            }
+
+            bool modifyDemands(state_t & state, demands_t & demands)
+            {
+                float _demands[2] = {demands.roll, demands.pitch};
+                for (int axis=0; axis<2; ++axis)
+                {
+                  float error = _demands[axis] * _demandsToAngle - state.eulerAngles[axis];
+                  _demands[axis] = error * PTerms[axis] + FF * _demands[axis];
+                }
+                
+                demands.roll = _demands[0];
+                demands.pitch = _demands[1];
+
+                // We've always gotta do this!
+                return true;
+            }
+
+    };  // class Level
+
+} // namespace

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -27,8 +27,6 @@
 #include <limits>
 #include <cmath>
 
-#include "receiver.hpp"
-#include "filters.hpp"
 #include "debug.hpp"
 #include "datatypes.hpp"
 #include "pidcontroller.hpp"
@@ -41,7 +39,7 @@ namespace hf {
 
         private:
           
-            const float FF = 0.5;
+            const float FEED_FORWARD = 0.5;
             
             float PTerms[2];
             
@@ -53,6 +51,11 @@ namespace hf {
             {
                 PTerms[0] = rollLevelP;
                 PTerms[1] = pitchLevelP;
+                // roll and pitch demands go between [-0.5, 0.5] so, for a
+                // given max angle, the following relation must hold true:
+                // 0.5 * _demandsToAngle = maxAngle
+                // Since we work in radians:
+                // _demandsToAngle = (maxAngle*PI/180) * 2
                 _demandsToAngle = maxAngle * 2 * M_PI / 180.0f;
             }
 
@@ -62,7 +65,7 @@ namespace hf {
                 for (int axis=0; axis<2; ++axis)
                 {
                   float error = _demands[axis] * _demandsToAngle - state.eulerAngles[axis];
-                  _demands[axis] = error * PTerms[axis] + FF * _demands[axis];
+                  _demands[axis] = error * PTerms[axis] + FEED_FORWARD * _demands[axis];
                 }
                 
                 demands.roll = _demands[0];


### PR DESCRIPTION
## Changes
1. Simplify stabilizer code
2. Add option to decouple roll and pitch rate PIDs
3. Include a new controller that allows to fly in self-level mode when used on top of the rate PID. This controller is a just a proportional controller with a feed forward term.
4. Add an example sketch for BonaDrone FC where this new controller is used.

@simondlevy , if the reasoning behind any of the changes is not clear I can write a brief justification for any of them.

## Notes

* `updateEulerAngles` and `computeCyclicPTerm` have been removed because they were setting directly the stabilizer's  `_PTerm` bypassing the modifications in the demands done by any other controller acting before the stabilizer. For example, the new self-level controller included int his PR.
* Since the rate-PID (`Stabilizer` class) should be the last one to act hackflight's architecture has been slightly modified (mainly the initialization of `_pid_controller_count` to 0) to allow adding controllers before the rate PID.

## Future ideas 
* Rename the `Stabilizer` class and `stabilizer.hpp` file to `rate` or `acro`.
* Maybe some of the hardcoded values (such as the feed forward term) can be re-defined as parameters of the level controller.
* Think of some improvements that can result in a better control sysem.
* What to do with the `proportionalCyclicDemand` term.
* Maybe re-do the derivative part of the rate-PID replacing the current sum of derivative errors with a low pass filter. 

## Updated Control diagrams

### Rate PID
![rate-pid](https://user-images.githubusercontent.com/9968427/46907501-b1da4480-cf13-11e8-9a19-79d25ac69b60.png)

### Level PID
![level-pid](https://user-images.githubusercontent.com/9968427/46907502-b56dcb80-cf13-11e8-9b85-522795162eaf.png)



**P.S.** New diagrams and demo video are on its way!

