### PR TITLE
Bonadrone board using MultiShot protocol

### DIFF
--- a/examples/Bonadrone/ESCCalibrationMultiShot/ESCCalibrationMultiShot.ino
+++ b/examples/Bonadrone/ESCCalibrationMultiShot/ESCCalibrationMultiShot.ino
@@ -1,0 +1,83 @@
+/*
+   ESCCalibration.ino : Calibrate Electronic Speed Controllers on Bonadrone Flight Controller
+
+   Hardware support:
+
+       https://github.com/simondlevy/grumpyoldpizza
+
+   Copyright (c) 2018 Juan Gallostra Acin & Pep Martí Saumell
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// PWM Values
+static uint16_t BASELINE = 100;
+static uint16_t MAXVAL   = 500;
+
+static uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
+static uint8_t LED_R = 13;
+static uint8_t LED_G = 38;
+static uint8_t LED_B = 26;
+
+static void initLedSequence()
+{
+  digitalWrite(LED_R, HIGH);
+  digitalWrite(LED_G, HIGH);
+  digitalWrite(LED_B, HIGH);
+  
+  digitalWrite(LED_R, LOW);
+  delay(500);
+  digitalWrite(LED_R, HIGH);
+  digitalWrite(LED_G, LOW);
+  delay(500);
+  digitalWrite(LED_G, HIGH);
+  digitalWrite(LED_B, LOW);
+  delay(500);
+}
+
+void setup(void)
+{
+
+  pinMode(LED_R, OUTPUT);  
+  pinMode(LED_G, OUTPUT);
+  pinMode(LED_B, OUTPUT);
+
+  initLedSequence();
+  
+  // Blue LED ON when calibrating (first part)
+  for (int k=0; k<4; ++k)
+  {
+    pinMode(MOTOR_PINS[k], OUTPUT);
+    analogWriteFrequency(MOTOR_PINS[k], 2000);
+    analogWriteRange(MOTOR_PINS[k], 10000);
+    analogWrite(MOTOR_PINS[k], MAXVAL);
+  }
+  delay(10000);
+  digitalWrite(LED_B, HIGH);
+  
+  // Green LED ON when calibrating (second part)
+  digitalWrite(LED_G, LOW);
+  for (int k=0; k<4; ++k)
+  {
+    analogWrite(MOTOR_PINS[k], BASELINE);
+  }
+  delay(10000);
+  digitalWrite(LED_G, HIGH);
+}
+
+void loop(void)
+{
+
+}

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -50,8 +50,8 @@ namespace hf {
             const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
             
             // Min, max PWM values
-            const uint16_t PWM_MIN = 1000;
-            const uint16_t PWM_MAX = 2000;
+            const uint16_t PWM_MIN = 100;
+            const uint16_t PWM_MAX = 500;
             
             // Paramters to experiment with ------------------------------------------------------------------------
 
@@ -109,7 +109,7 @@ namespace hf {
 
             void writeMotor(uint8_t index, float value)
             {
-                analogWrite(MOTOR_PINS[index], (uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)) >> 3);
+                analogWrite(MOTOR_PINS[index], (uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)));
             }
 
             virtual uint32_t getMicroseconds(void) override
@@ -159,7 +159,9 @@ namespace hf {
                 // Connect to the ESCs and send them the baseline values
                 for (uint8_t k=0; k<4; ++k) {
                   pinMode(MOTOR_PINS[k], OUTPUT);
-                  analogWrite(MOTOR_PINS[k], PWM_MIN>>3);
+                  analogWriteFrequency(MOTOR_PINS[k], 2000);
+                  analogWriteRange(MOTOR_PINS[k], 10000);
+                  analogWrite(MOTOR_PINS[k], PWM_MIN);
                 }
 
                 // Start I^2C


### PR DESCRIPTION
This PR modifies the protocol used to control the motors when using BonaDrone's board code (`src/boards/bonadrone.hpp`). Instead of using the standard ESC protocol at 488Hz BonaDrone's board will, if accepted, control the motors via the MultiShot protocol at 2000Hz. 

For a comparison of different protocols see: https://quadmeup.com/pwm-oneshot125-oneshot42-and-multishot-comparison/