### PR TITLE
Altitude Hold controller

### DIFF
--- a/examples/Bonadrone/SBUSAltHold/SBUSAltHold.ino
+++ b/examples/Bonadrone/SBUSAltHold/SBUSAltHold.ino
@@ -1,0 +1,129 @@
+/*
+   SBUSAltHold.ino : Hackflight sketch for Bonadrone flight controller with SBUS receiver
+   that allows altitude hold flight mode
+
+   Additional libraries needed:
+
+       https://github.com/simondlevy/LSM6DSM
+       https://github.com/simondlevy/CrossPlatformDataBus
+       https://github.com/simondlevy/SBUSRX
+       https://github.com/simondlevy/VL53L1X
+
+   Hardware support for Bonadrone flight controller:
+
+       https://github.com/simondlevy/grumpyoldpizza
+
+   Copyright (c) 2018 Juan Gallostra & Simon D. Levy
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Arduino.h>
+#include <VL53L1X.h>
+
+#include "hackflight.hpp"
+#include "boards/bonadrone.hpp"
+#include "receivers/sbus.hpp"
+#include "mixers/quadx.hpp"
+
+#include "sensors/rangefinder.hpp"
+
+#include "pidcontrollers/level.hpp"
+#include "pidcontrollers/althold.hpp"
+
+class VL53L1X_Rangefinder : public hf::Rangefinder {
+
+    private:
+
+        VL53L1X _distanceSensor;
+
+    protected:
+
+        virtual bool distanceAvailable(float & distance) override
+        {
+            if (_distanceSensor.newDataReady()) {
+                distance = _distanceSensor.getDistance() / 1000.f; // mm => m
+                return true;
+            }
+            return false;
+        }
+
+    public:
+
+        void begin(void)
+        {
+            _distanceSensor.begin();
+        }
+}; // class VL53L1X_Rangefinder 
+
+// Change this as needed
+#define SBUS_SERIAL Serial1
+
+static constexpr uint8_t CHANNEL_MAP[6] = {2,0,1,3,5,4};
+
+hf::Hackflight h;
+
+hf::SBUS_Receiver rc = hf::SBUS_Receiver(CHANNEL_MAP, SERIAL_SBUS, &SBUS_SERIAL);
+
+hf::MixerQuadX mixer;
+
+VL53L1X_Rangefinder rangefinder;
+
+hf::Rate ratePid = hf::Rate(
+        0.10f,  // Gyro Roll/Pitch P
+        0.01f,  // Gyro Roll/Pitch I
+        0.05f,  // Gyro Roll/Pitch D
+        0.10f,  // Gyro yaw P
+        0.01f,  // Gyro yaw I
+        5.00f); // Demands to rate
+
+hf::Level level = hf::Level(
+        0.25f,   // Roll Level P
+        0.25f);  // Pitch Level P
+
+hf::AltitudeHold althold = hf::AltitudeHold(
+        0.30f,   // Altitude Hold P
+        0.20f,   // Altitude Hold Velocity P
+        0.00f,   // Altitude Hold Velocity I
+        1.00f);  // Altitude Hold Velocity D
+
+
+void setup(void)
+{
+    // begin the serial port for the ESP32
+    Serial4.begin(115200);
+
+    // Trim receiver via software
+    rc.setTrimRoll(-0.0012494f);
+    rc.setTrimPitch(-0.0058769f);
+    rc.setTrimYaw(-0.0192190f);
+
+    // 0 means the controller will always be active, but by changing
+    // that number it can be linked to a different aux state
+    h.addPidController(&althold, 2);
+    h.addPidController(&level, 0);
+
+    h.init(new hf::BonadroneMultiShot(), &rc, &mixer, &ratePid);
+    
+    // Add rangefinder sensor
+    rangefinder.begin();
+    h.addSensor(&rangefinder);
+    
+}
+
+void loop(void)
+{
+    h.update();
+}

--- a/examples/Bonadrone/SBUSAltHold/SBUSAltHold.ino
+++ b/examples/Bonadrone/SBUSAltHold/SBUSAltHold.ino
@@ -94,11 +94,10 @@ hf::Level level = hf::Level(
         0.25f);  // Pitch Level P
 
 hf::AltitudeHold althold = hf::AltitudeHold(
-        0.30f,   // Altitude Hold P
-        0.20f,   // Altitude Hold Velocity P
-        0.00f,   // Altitude Hold Velocity I
-        1.00f);  // Altitude Hold Velocity D
-
+        1.00f,   // Altitude Hold P
+        0.15f,   // Altitude Hold Velocity P
+        0.01f,   // Altitude Hold Velocity I
+        0.05f);  // Altitude Hold Velocity D
 
 void setup(void)
 {

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -72,38 +72,38 @@ namespace hf {
             
               bool modifyDemands(state_t & state, demands_t & demands)
               {
-                // Don't do anything till we've reached sufficient altitude
-                if (state.altitude < _minAltitude) return false;
+                  // Don't do anything till we've reached sufficient altitude
+                  if (state.altitude < _minAltitude) return false;
 
-                // Reset altitude target if moved into stick deadband
-                bool inBandCurr = inBand(demands.throttle);
-                if (inBandCurr && !_inBandPrev) {
-                    _altitudeTarget = state.altitude;
-                    resetErrors();
-                }
-                _inBandPrev = inBandCurr;
+                  // Reset altitude target if moved into stick deadband
+                  bool inBandCurr = inBand(demands.throttle);
+                  if (inBandCurr && !_inBandPrev) {
+                      _altitudeTarget = state.altitude;
+                      resetErrors();
+                  }
+                  _inBandPrev = inBandCurr;
                 
-                // Altitude Hold P(PID) control action computation
-                uint32_t _currentTime = micros();
-                float dt = (_currentTime - _previousTime) / 1000000.0f;
-                _previousTime = _currentTime;
-                // Compute vertical velocity setpoint and error
-                _velocityTarget = (_altitudeTarget - state.altitude) * _altHoldP;
-                float velocityError = _velocityTarget - state.variometer;
-                // Update error integral and error derivative
-                _integralError = Filter::constrainAbs(_integralError + velocityError * dt, WINDUP_MAX);
-                _deltaError = (velocityError - _lastError) / dt;
-                _lastError = velocityError;
-                // Compute control action
-                float throttleCorrection = _altHoldVelP * velocityError +
-                                           _altHoldVelD * _deltaError +
-                                           _altHoldVelI * _integralError;                       
-                // Throttle: inside stick deadband, adjust by P(PID);
-                // outside deadband, respond to stick demand
-                demands.throttle = inBandCurr ? 
-                    HOVER_THROTTLE + throttleCorrection:
-                    demands.throttle;
-                return inBandCurr;
+                  // Altitude Hold P(PID) control action computation
+                  uint32_t _currentTime = micros();
+                  float dt = (_currentTime - _previousTime) / 1000000.0f;
+                  _previousTime = _currentTime;
+                  // Compute vertical velocity setpoint and error
+                  _velocityTarget = (_altitudeTarget - state.altitude) * _altHoldP;
+                  float velocityError = _velocityTarget - state.variometer;
+                  // Update error integral and error derivative
+                  _integralError = Filter::constrainAbs(_integralError + velocityError * dt, WINDUP_MAX);
+                  _deltaError = (velocityError - _lastError) / dt;
+                  _lastError = velocityError;
+                  // Compute control action
+                  float throttleCorrection = _altHoldVelP * velocityError +
+                                             _altHoldVelD * _deltaError +
+                                             _altHoldVelI * _integralError;                       
+                  // Throttle: inside stick deadband, adjust by P(PID);
+                  // outside deadband, respond to stick demand
+                  demands.throttle = inBandCurr ? 
+                      HOVER_THROTTLE + throttleCorrection:
+                      demands.throttle;
+                  return inBandCurr;
               }
               
               virtual bool shouldFlashLed(void) override 
@@ -126,10 +126,10 @@ namespace hf {
                 _altHoldVelD(altHoldVelD),
                 _minAltitude(minAltitude)
             {
-              // Initialize errors
-              resetErrors();
-              _previousTime = micros();
-              _inBandPrev = false;
+                // Initialize errors
+                resetErrors();
+                _previousTime = micros();
+                _inBandPrev = false;
             }
 
     };  // class AltitudeHold

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -1,0 +1,113 @@
+/*
+   althold.hpp : Altitude hold PID controller
+
+   Copyright (c) 2018 Juan Gallostra and Simon D. Levy
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <limits>
+#include <cmath>
+
+#include "receiver.hpp"
+#include "filters.hpp"
+#include "debug.hpp"
+#include "datatypes.hpp"
+#include "pidcontroller.hpp"
+
+namespace hf {
+
+    class AltitudeHold : public PID_Controller {
+
+        friend class Hackflight;
+
+        private: 
+
+            // Arbitrary constants
+            const float WINDUP_MAX             = 0.40f;
+            const float HOVER_THROTTLE         = 0.05f;
+            const float MIN_ALTITUDE           = 0.10f;
+
+            // PID constants set in constructor
+            float _altHoldP;
+            float _altHoldVelP;
+            float _altHoldVelI;
+            float _altHoldVelD;
+            
+            // Required constants
+            float _lastError;
+            float _deltaError;
+            float _integralError;
+            float _velocityTarget;
+            float _altitudeTarget;
+            uint32_t _previousTime;
+            
+
+            void resetErrors(void)
+            {
+                _lastError = 0;
+                _deltaError = 0;
+                _integralError = 0;
+            }
+
+        public:
+
+            AltitudeHold(float altHoldP, float altHoldVelP, float altHoldVelI, float altHoldVelD) :
+                _altHoldP(altHoldP), 
+                _altHoldVelP(altHoldVelP), 
+                _altHoldVelI(altHoldVelI),
+                _altHoldVelD(altHoldVelD) 
+            {
+              // Initialize errors
+              resetErrors();
+              _previousTime = micros();
+            }
+
+            bool modifyDemands(state_t & state, demands_t & demands)
+            {
+              uint32_t _currentTime = micros();
+              float dt = (_currentTime - _previousTime) / 1000000.0f;
+              _previousTime = _currentTime;
+              _altitudeTarget = 0.20f;
+              // Compute velocity setpoint
+              _velocityTarget = (_altitudeTarget - state.altitude)*_altHoldP;
+              // Compute errors
+
+              float velocityError = _velocityTarget - state.variometer;
+              // Update error integral and error derivative
+              _integralError = Filter::constrainAbs(_integralError + velocityError * dt, WINDUP_MAX);
+              _deltaError = (velocityError - _lastError) / dt;
+              _lastError = velocityError;
+              float throttleCorrection = _altHoldVelP * velocityError +
+                                         _altHoldVelD * _deltaError +
+                                         _altHoldVelI * _integralError;
+              demands.throttle = HOVER_THROTTLE + throttleCorrection;
+
+              return true;
+            }
+            
+            virtual bool shouldFlashLed(void) override 
+            {
+                return true;
+            }
+
+    };  // class AltitudeHold
+
+} // namespace


### PR DESCRIPTION
This PR adds an Altitude Hold controller to Hackflight (Loiter is on the way!) and an example sketch to test it with BonaDrone's Mosquito 150.

**Test before merging (and at own risk! :sweat_smile: )**: I have tested the controller with a fixed `_altitudeTarget`, but not after the modifications to allow setting the altitude target via the stick deadband. My Mosquito is currently out of service, but I will further test it when fixed. Maybe it is worth to wait a bit until we test it further.

The implementation of the controller is a P(PID), the same that iNav uses and is shown in the image below.

![image](https://user-images.githubusercontent.com/9968427/47387215-fbded980-d70e-11e8-8cfa-ef4983cd3179.png)
**Source**: [iNav](https://github.com/iNavFlight/inav/wiki/Developer-info)


 