### PR TITLE
Calibrate IMU on startup when using BonaDrone's FC

### DIFF
--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -104,6 +104,7 @@ namespace hf {
 
             Bonadrone(void) : ArduinoBoard(38, true) // inverted LED signal
             {
+                setLed(true);
                 // Configure interrupt
                 pinMode(LSM6DSM_INTERRUPT_PIN, INPUT);
 
@@ -138,6 +139,7 @@ namespace hf {
                 _lsm6dsm.calibrate(GYRO_BIAS, ACCEL_BIAS);
                 // Clear the interrupt
                 _lsm6dsm.clearInterrupt();
+                setLed(false);
             }
 
     }; // class Bonadrone

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -134,6 +134,8 @@ namespace hf {
 
                 delay(100);
 
+                // Calibrate IMU on startup
+                _lsm6dsm.calibrate(GYRO_BIAS, ACCEL_BIAS);
                 // Clear the interrupt
                 _lsm6dsm.clearInterrupt();
             }


### PR DESCRIPTION
## P.R. Changes
When using BonaDrone's FC take advantage of the LSM6DSM's `calibrate` method to compute the IMU biases each time the board is powered instead of using hard-coded values.

To notice the user when the board initialization has finished a LED is turned on at the beginning of the process and turned off when it finishes.

### Notes
The main **advantage** is that biases will be more accurate and the main **disadvantage** that the board will have to remain still when being powered up. 
