### PR TITLE
Allow to trigger failsafe on low battery

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -71,6 +71,7 @@ namespace hf {
             //----------------------------------------- Safety -----------------------------------------------------------
             virtual void showArmedStatus(bool armed) { (void)armed; }
             virtual void flashLed(bool shouldflash) { (void)shouldflash; }
+            virtual bool isBatteryLow(void) { return false; }
 
             //--------------------------------------- Debugging ----------------------------------------------------------
             static void  outbuf(char * buf);

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -151,7 +151,7 @@ namespace hf {
 
             void checkFailsafe(void)
             {
-                if (_state.armed && _receiver->lostSignal()) {
+                if (_state.armed && (_receiver->lostSignal() || _board->isBatteryLow())) {
                     _mixer->cutMotors();
                     _state.armed = false;
                     _failsafe = true;


### PR DESCRIPTION
As a safety measure, I think it makes sense to add the option of triggering failsafe when battery is low.

To do so, I suggest to add a new virtual method (`isBatteryLow`) to the `Board` class that defaults to `false` and that can be overwritten when subclassing it. This method is then called in Hackflight's  `checkFailsafe` method. If it returns `true` and the UAV is armed failsafe will be triggered.