### PR TITLE
Add methods for sending Bytes, Shorts and Ints in cpp auto-generated MSP parser 

### DIFF
--- a/extras/parser/msppg.py
+++ b/extras/parser/msppg.py
@@ -215,13 +215,15 @@ class Python_Emitter(LocalCodeEmitter):
 
 class HPP_Emitter(CodeEmitter):
 
-    type2decl = {'byte': 'uint8_t', 'short' : 'int16_t', 'float' : 'float', 'int' : 'int32_t'}
+    type2decl    = {'byte': 'uint8_t', 'short' : 'int16_t', 'float' : 'float', 'int' : 'int32_t'}
+    type2keyword = {'byte': 'Byte', 'short' : 'Short', 'float' : 'Float', 'int' : 'Int'}
 
     def __init__(self, msgdict):
 
         CodeEmitter.__init__(self)
 
         self.type2decl = HPP_Emitter.type2decl
+        self.type2keyword = HPP_Emitter.type2keyword
 
         # Create C++ header file
         self._copyfile('mspparser.hpp', 'mspparser.hpp', '../../src')
@@ -262,9 +264,9 @@ class HPP_Emitter(CodeEmitter):
                     self.output.write(', ')
             self.output.write(');\n')
             if msgid < 200:
-                self.output.write(6*self.indent + ('prepareToSendFloats(%d);\n' % nargs))
+                self.output.write(6*self.indent + ('prepareToSend%ss(%d);\n' % (self.type2keyword[argtype], nargs)))
                 for argname in argnames:
-                    self.output.write(6*self.indent + ('sendFloat(%s);\n' % argname))
+                    self.output.write(6*self.indent + ('send%s(%s);\n' % (self.type2keyword[argtype], argname)))
                 self.output.write(6*self.indent + "serialize8(_checksum);\n")
             self.output.write(6*self.indent + '} break;\n\n')
 

--- a/extras/parser/resources/mspparser.hpp
+++ b/extras/parser/resources/mspparser.hpp
@@ -62,6 +62,12 @@ namespace hf {
 
             serialState_t  _state;
 
+            void clearOutBuff(void)
+            {
+                _outBufSize = 0;
+                _outBufIndex = 0;
+            }
+
             void serialize8(uint8_t a)
             {
                 _outBuf[_outBufSize++] = a;
@@ -99,12 +105,48 @@ namespace hf {
 
             void prepareToSendFloats(uint8_t count)
             {
-                _outBufSize = 0;
-                _outBufIndex = 0;
+                clearOutBuff();
                 headSerialReply(count*4);
             }
 
             void sendFloat(float src)
+            {
+                uint32_t a;
+                memcpy(&a, &src, 4);
+                serialize32(a);
+            }
+
+            void prepareToSendBytes(uint8_t count)
+            {
+                clearOutBuff();
+                headSerialReply(count);
+            }
+
+            void sendByte(uint8_t src)
+            {
+                serialize8(src);
+            }
+
+            void prepareToSendShorts(uint8_t count)
+            {
+                clearOutBuff();
+                headSerialReply(2*count);
+            }
+
+            void sendShort(uint16_t src)
+            {
+                uint32_t a;
+                memcpy(&a, &src, 2);
+                serialize16(a);
+            }
+
+            void prepareToSendInts(uint8_t count)
+            {
+                clearOutBuff();
+                headSerialReply(4*count);
+            }
+
+            void sendInt(uint32_t src)
             {
                 uint32_t a;
                 memcpy(&a, &src, 4);

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -62,6 +62,12 @@ namespace hf {
 
             serialState_t  _state;
 
+            void resetOutBuff(void)
+            {
+                _outBufSize = 0;
+                _outBufIndex = 0;
+            }
+
             void serialize8(uint8_t a)
             {
                 _outBuf[_outBufSize++] = a;
@@ -99,12 +105,48 @@ namespace hf {
 
             void prepareToSendFloats(uint8_t count)
             {
-                _outBufSize = 0;
-                _outBufIndex = 0;
+                resetOutBuff();
                 headSerialReply(count*4);
             }
 
             void sendFloat(float src)
+            {
+                uint32_t a;
+                memcpy(&a, &src, 4);
+                serialize32(a);
+            }
+
+            void prepareToSendBytes(uint8_t count)
+            {
+                resetOutBuff();
+                headSerialReply(count);
+            }
+
+            void sendByte(uint8_t src)
+            {
+                serialize8(src);
+            }
+
+            void prepareToSendShorts(uint8_t count)
+            {
+                resetOutBuff();
+                headSerialReply(2*count);
+            }
+
+            void sendShort(uint16_t src)
+            {
+                uint32_t a;
+                memcpy(&a, &src, 2);
+                serialize16(a);
+            }
+
+            void prepareToSendInts(uint8_t count)
+            {
+                resetOutBuff();
+                headSerialReply(4*count);
+            }
+
+            void sendInt(uint32_t src)
             {
                 uint32_t a;
                 memcpy(&a, &src, 4);


### PR DESCRIPTION
## Issue/Feature this PR addresses
Include support in the auto-generated `mspparser.hpp` (via `msppg.py`) for sending  MSP messages with:
1. An ID code lower than 200
2. A payload type of bytes, shorts or integers 

## Current behavior
The payload type is always `float` for all messages with an ID code lower than 200 in the auto generated `mspparser.hpp` independently of the data type specified in `messages.json`.

## Desired behavior after merge
1. Auto-generated `mspparser.hpp` takes into account the specified payload type (in `messages.json`) for MSP messages with an ID lower than 200.
2. MSP messages created via MspParser present the specified payload. 