### PR TITLE
Add support for Xbox Series S|X controllers in the Webots Simulator

### DIFF
--- a/webots/README.md
+++ b/webots/README.md
@@ -31,6 +31,7 @@ are currently supported:
 * [MGEAR Wired Controller for PS3](https://www.officedepot.com/a/products/7123231/Gear-Wired-Controller-For-PS3-Black/)
 * [Logitech Gamepad F310](https://www.amazon.com/gp/product/B003VAHYQY)
 * [Logitech Extreme 3D Pro](https://www.amazon.com/gp/product/B00009OY9U)
+* [Xbox Series S|X Controller](https://a.co/d/7QbSZaZ)
 * [FrSky XSR-SIM USB Dongle](https://www.amazon.com/gp/product/B07GD6ZLW7)
 * [Spektrum Ws2000 Wireless USB RC Flight Simulator Dongle](https://www.amazon.com/gp/product/B07ZK1R32H)
 * Nyko 83069 Playstation(R)3 Core Wired Controller

--- a/webots/controllers/support.hpp
+++ b/webots/controllers/support.hpp
@@ -118,6 +118,8 @@ class Simulator {
                 joystick_t {-2,  3, -4, 1, true } },
             { "Logitech Gamepad F310",
                 joystick_t {-2,  4, -5, 1, true } },
+            { "Microsoft Xbox Series S|X Controller",
+                joystick_t {-2,  4, -5, 1, true } },
 
             // Classic throttle
             { "Logitech Logitech Extreme 3D",


### PR DESCRIPTION
I wanted to add support for the controller that I have at my house.

I copied the `joystick_t` from the Logitech Gamepad since that seems most similar to the XBox controller. This means that the left stick controls controls height and the yaw while the right stick controls the pitch and roll